### PR TITLE
Fix www-authenticate

### DIFF
--- a/digest.py
+++ b/digest.py
@@ -84,7 +84,8 @@ class DigestAuthMixin(object):
     def createAuthHeader(self):
         self.set_status(401)
         nonce = self._create_nonce()
-        self.set_header("WWW-Authenticate", "Digest algorithm=MD5 realm=%s qop=auth nonce=%s" % (self.realm, nonce))
+        self.set_header('WWW-Authenticate', 'Digest algorithm=MD5, realm="%s", qop=auth, nonce=%s' % (self.realm, nonce))
+        self.write('please authenticate\n')
         self.finish()
 
         return False

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+setup(name='curtain',version='1.0',package_dir={'curtain':''},packages=['curtain'],)


### PR DESCRIPTION
Here is a pull request for the issue I sent you an e-mail about. Curl and Chrome require that www-authenticate header have commas.
