### PR TITLE
Fix the IE can't pass the authentication

### DIFF
--- a/digest.py
+++ b/digest.py
@@ -71,7 +71,7 @@ class DigestAuthMixin(object):
         try:
             n = len("Digest ")
             authheader = authheader[n:].strip()
-            items = authheader.split(", ")
+            items = authheader.split(",")
             keyvalues = [i.split("=", 1) for i in items]
             keyvalues = [(k.strip(), v.strip().replace('"', '')) for k, v in keyvalues]
             self.params = dict(keyvalues)


### PR DESCRIPTION
Some of agents, such as Internet Explorer, when client type the user&password , the agent will combine all of this information without a space after the comma.like:

```
username="jonesy",realm="Authusers",...omit for brief...
```
